### PR TITLE
Make GitHub detect *.txt as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.txt linguist-language=Forth
+/ledcomm.txt  linguist-language=Text
+/common/assembler-readme.txt linguist-language=Text


### PR DESCRIPTION
Hello,

Please merge this, if you'd like GitHub to detect the `.txt` files as Forth.  Except two text files.

Thanks!
